### PR TITLE
Make Python3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
                    'Intended Audience :: Developers',
                    'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
                    'Topic :: Database',
-                   'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3.13',
 
                   ],
     )

--- a/tests.py
+++ b/tests.py
@@ -6,9 +6,6 @@ Tests for DictLiteStore.
 '''
 
 import sys
-reload(sys)
-sys.setdefaultencoding('utf-8') # pylint: disable=no-member
-
 import os
 import os.path
 from dictlitestore import DictLiteStore, NoJSON, json_or_raw
@@ -101,8 +98,8 @@ class TestBasicDataTypes(Basic):
         self.store_and_compare(a)
 
     def test_function(self):
-        a = {'col1':'should work', 'col2': map}
-        b = {'col1':'should work', 'col2': '<built-in function map>'}
+        a = {'col1':'should work', 'col2': len}
+        b = {'col1':'should work', 'col2': '<built-in function len>'}
         self.store_and_compare(a, b)
 
     def test_class(self):


### PR DESCRIPTION
Doesn't look like you've touched this in a while, but this change set is (I believe) the minimal changes needed to make it Python3 compatible. The tests pass and I've been using it in a small project. (I also removed the type constraint on the implicit ID column to allow for UUIDs.)